### PR TITLE
Update version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxl",
-  "version": "0.20.0",
+  "version": "1.0.0",
   "description": "Layout primitives for the styled component age.",
   "author": "Crema",
   "repository": {


### PR DESCRIPTION
## Overview

This represents a breaking API change, so I guess it's time to go to `v1.0.0` 🎉 

## Review Checklist

- [x] Merge destination is correct