### PR TITLE
FIX: Intersect custom component props with props

### DIFF
--- a/src/lib/boxl/test.tsx
+++ b/src/lib/boxl/test.tsx
@@ -48,7 +48,8 @@ describe("boxl", () => {
       const P: SFC<BoxlComponentProps> = ({ boxlProps, ...props }) => (
         <p {...props} />
       );
-      const received = TestRenderer.create(<Boxl component={P} />);
+      const B = b(P)();
+      const received = TestRenderer.create(<B />);
       expect(received).toMatchSnapshot();
     });
   });

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -115,7 +115,7 @@ export type BoxlComponentProps<P = {}, T = {}> = {
   boxlProps?: BoxlPropsBase<P, T>;
 } & P;
 
-export type BoxlProps<P = {}, T = {}, E = {}> = BoxlPropsBase<P, T> &
+export type BoxlProps<P = {}, T = {}, E = {}> = BoxlPropsBase<P & E, T> &
   BoxlElement<E> &
   P;
 

--- a/src/stories/component.stories.tsx
+++ b/src/stories/component.stories.tsx
@@ -23,9 +23,9 @@ storiesOf("component", module)
     };
 
     const ThingStyled = boxl(Thing)({
-      style: `
+      style: s => s`
         background: blue;
-        padding: 2em;
+        padding: ${p => (p.foo ? "2em" : "1em")};
       `,
     });
     return <ThingStyled foo="test extra props">hi</ThingStyled>;


### PR DESCRIPTION
## Overview

Custom component types were not being intersected internally with props in `BoxlProps` which meant that these types were not available on `props` inside interpolation functions.

This fixes that issue.

## Review Checklist

- [x] Merge destination is correct
- [x] Tests cases have been added where appropriate (Jest, Loki, Cypress)
- [x] Code is correct as understood and conforms to quality standards

## Testing Instructions

1. Create new component passing a custom component: 
```ts
const Thing: React.SFC<BoxlComponentProps<{ foo: string }>> = ({
  boxlProps,
  foo,
  ...props
}) => {
  return <a {...props}>{props.children}</a>;
};

const ThingStyled = boxl(Thing)({
  style: s => s`
    background: blue;
    padding: ${p => (p.foo ? "2em" : "1em")};
  `,
});
```
2. Ensure that custom component props (in this case `foo`) are available internally (in this case inside style interpolation