### PR TITLE
UPDATE: TypeScript ^3.2.2 → ^3.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "boxl",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15400,9 +15400,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.2.2.tgz",
-      "integrity": "sha512-VCj5UiSyHBjwfYacmDuc/NOk4QQixbE+Wn7MFJuS0nRuPQbof132Pw4u53dm264O8LPc2MVsc7RJNml5szurkg==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "ua-parser-js": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "boxl",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "Layout primitives for the styled component age.",
   "author": "Crema",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "tslint-config-prettier": "^1.15.0",
     "tslint-plugin-prettier": "^1.3.0",
     "tslint-react": "^3.6.0",
-    "typescript": "^3.2.2"
+    "typescript": "^3.4.5"
   },
   "loki": {
     "requireReference": true,

--- a/src/lib/boxl/index.tsx
+++ b/src/lib/boxl/index.tsx
@@ -10,7 +10,7 @@ import {
 
 type BoxlThunkReturn<
   T = {},
-  E extends React.ReactType = E,
+  E extends React.ReactType = React.ReactType,
   EE extends InferPropsType<E> = InferPropsType<E>
 > = <
   P,
@@ -22,7 +22,7 @@ type BoxlThunkReturn<
 
 function boxlThunk<
   T = {},
-  E extends React.ReactType = E,
+  E extends React.ReactType = React.ReactType,
   EE extends InferPropsType<E> = InferPropsType<E>
 >(component?: E): BoxlThunkReturn<T, E> {
   return <
@@ -57,7 +57,7 @@ const boxls = domElements.reduce(
 
 export const boxl = Object.assign(boxlThunk, boxls); // tslint:disable-line
 
-export type Boxl<T = {}> = (<E extends React.ReactType = E>(
+export type Boxl<T = {}> = (<E extends React.ReactType = React.ReactType>(
   component: E
 ) => BoxlThunkReturn<T, E>) &
   Boxls<T>;


### PR DESCRIPTION
## Overview

Updates `typescript` version` ^3.2.2` → `^3.4.5` and fixes generic defaults

## Review Checklist

- [x] Merge destination is correct